### PR TITLE
implement infestor test and logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ All the options the charge takes are interoperable with [divshot.io's configurat
 
 For the most up-to-date reference of options for each middleware be sure to check out their [individual project repos](#middleware-stack).
 
+> note: if you attempt to use `journalist` to write content into your response, we will automatically turn off gzip.
+
 #### Methods
 
 ##### start(opts)

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -21,6 +21,7 @@ module.exports = charge = (root, opts) ->
   opts = parse_options(root, opts)
   if opts.root then root = path.resolve(opts.root)
   if typeof opts.websockets == 'undefined' then opts.websockets = true
+  if opts.write then opts.gzip = false
 
   app = connect()
 

--- a/test/fixtures/options/infestor.html
+++ b/test/fixtures/options/infestor.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h2> hi </h2>
+  </body>
+</html>

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -83,10 +83,12 @@ describe 'options', ->
       res.text.should.equal("<p>flagrant error!</p>\n")
       done()
 
-  it.skip 'should inject content if write is passed', (done) ->
+  it 'should inject content if write is passed', (done) ->
     app = charge(opts_path, 'write.json')
 
-    chai.request(app).get('/').res (res) ->
+    chai.request(app).get('/infestor.html').res (res) ->
+      res.should.have.status(200)
+      res.should.have.be.html
       res.text.should.match /hello there!/
       done()
 


### PR DESCRIPTION
- no longer skip infestor test
- assert a few more things in infestor test
- test now has `</html>` to injectAt
- we disable gzip if you attempt to write the res

jeff and I discussed this a little bit and we basically landed on the fact that if you want to write to the response then you can't do that when gzip is on. along with this, `alchemist` turns off gzip by default but I've also manually disabled gzip if you pass a `write` option. i've also made note in the readme of that quirk. 

/cc @jenius @joshrowley 
