### PR TITLE
Add compression middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ charge.pathologist
 charge.escapist
 charge.publicist
 charge.archivist
+charge.minimist
 charge.journalist
 charge.columnist
 charge.alchemist
@@ -56,6 +57,7 @@ Each of these are middleware functions, compatible with [connect](http://www.sen
 - [Escapist](https://github.com/carrot/escapist-middleware) (ignore files)
 - [Publicist](https://github.com/carrot/publicist-middleware) (basic auth)
 - [Archivist](https://github.com/carrot/archivist-middleware) (cache control)
+- [Minimist](https://github.com/expressjs/compression) (gzip content)
 - [Journalist](https://github.com/samccone/infestor) (inject content)
 - [Columnist](https://github.com/expressjs/morgan) (logging)
 - [Alchemist](https://github.com/carrot/alchemist-middleware) (static file server)

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -22,6 +22,7 @@ module.exports = charge = (root, opts) ->
   opts = parse_options(root, opts)
   if opts.root then root = path.resolve(opts.root)
   if typeof opts.websockets == 'undefined' then opts.websockets = true
+  if opts.gzip == true then opts.gzip = { threshold: 0 }
   if opts.write then opts.gzip = false
   if typeof opts.log == 'undefined' then opts.log = 'dev'
 
@@ -32,6 +33,7 @@ module.exports = charge = (root, opts) ->
   if opts.exclude       then app.use(m.escapist(opts.exclude))
   if opts.auth          then app.use(m.publicist(opts.auth))
   if opts.cache_control then app.use(m.archivist(opts.cache_control))
+  if opts.gzip          then app.use(m.minimist(opts.gzip))
   if opts.write         then app.use(m.journalist(opts.write))
   if opts.log           then app.use(m.columnist(opts.log))
 

--- a/lib/middleware.coffee
+++ b/lib/middleware.coffee
@@ -8,3 +8,4 @@ module.exports =
   columnist: require 'morgan'
   pathologist: require 'pathologist-middleware'
   journalist: require 'infestor'
+  minimist: require 'compression'

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "update-notifier": "^0.1.8",
     "colors": "^0.6.2",
     "anti-matter": "0.0.1",
-    "morgan": "1.0.x"
+    "morgan": "1.0.x",
+    "compression": "^1.0.2"
   }
 }

--- a/test/fixtures/options/clean_urls.json
+++ b/test/fixtures/options/clean_urls.json
@@ -1,3 +1,4 @@
 {
-  "clean_urls": true
+  "clean_urls": true,
+  "log": false
 }

--- a/test/fixtures/options/exclude.json
+++ b/test/fixtures/options/exclude.json
@@ -1,3 +1,4 @@
 {
-  "exclude": "/index.html"
+  "exclude": "/index.html",
+  "log": false
 }

--- a/test/fixtures/options/gzip.json
+++ b/test/fixtures/options/gzip.json
@@ -1,0 +1,4 @@
+{
+  "gzip": true,
+  "log": false
+}

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -100,6 +100,16 @@ describe 'options', ->
       res.text.should.match /hello there!/
       done()
 
+  it 'should gzip content if gzip is passed', (done) ->
+    app = charge(opts_path, 'gzip.json')
+
+    chai.request(app).get('/').res (res) ->
+      res.headers['content-encoding'].should.equal('gzip')
+      res.should.have.status(200)
+      res.should.have.be.html
+      res.text.should.equal('<p>wow</p>\n')
+      done()
+
 describe 'instance', ->
 
   before -> @app = charge(basic_path, { log: false })


### PR DESCRIPTION
With gzip no longer activating through alchemist, we need a way to make the compression happen. I'm actually kind of glad that this can be a separate piece of middleware, it feels like it belongs that way.

This guy comes with sort of a "secret option" - while most people want to turn on gzip and have everything compressed (which you can do by passing `gzip: true` as before), you can actually set a threshold for content size, that if exceeded, the content will be gzipped. Pretty nice. You can activate this by passing `{ threshold: 1000 }` to the `gzip` option rather than a boolean.
