### PR TITLE
customized middleware example

### DIFF
--- a/examples/customize_middleware/index.html
+++ b/examples/customize_middleware/index.html
@@ -1,0 +1,21 @@
+<html>
+  <head>
+    <title>Charge - Customized Middleware Example</title>
+    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+    <style>
+      body { font-family: 'Open Sans', sans-serif; padding: 40px 0}
+      #content { max-width: 920px; margin: 0 auto; padding: 0 20px }
+      a:link, a:visited { color: #0074D9 }
+    </style>
+  </head>
+  <body>
+    <div id="content">
+
+      <h2>Charge - Customized Middleware Example</h2>
+      <p>This page is being served by <a href="http://github.com/carrot/charge">Charge</a>.</p>
+
+      <p>If you want to see Charge's custom error page (provided by <a href="http://github.com/carrot/apology-middleware">apology-middleware</a>), try visiting <a href="/non-existant.html">a url that doesn't exist</a></p>
+
+    </div>
+  </body>
+</html>

--- a/examples/customize_middleware/package.json
+++ b/examples/customize_middleware/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "customize_middleware",
+  "version": "0.0.0",
+  "description": "In this example, we'll replace charge's logger of choice [morgan](https://github.com/expressjs/morgan) with [connect's built-in logger](http://www.senchalabs.org/connect/logger.html).",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "connect": "~2.17.1"
+  }
+}

--- a/examples/customize_middleware/readme.md
+++ b/examples/customize_middleware/readme.md
@@ -1,0 +1,15 @@
+### Charge Customize Middleware Example
+
+In this example, we'll replace charge's logger of choice [morgan](https://github.com/expressjs/morgan) with [connect's built-in logger](http://www.senchalabs.org/connect/logger.html).
+
+While this is a trivial example, it's meant to show you that since charge simply returns an array of middleware, you can swap in and out whatever middleware your heart desires.
+
+To see the project (particularly the logger) in action, you'll have to assure that you have connect installed, and then you can run the server.
+
+```
+$ cd examples/customize_middlware
+$ npm install
+$ npm start
+```
+
+Then open up `localhost:1111` in your browser to get those logs logging.

--- a/examples/customize_middleware/server.js
+++ b/examples/customize_middleware/server.js
@@ -1,0 +1,13 @@
+require('coffee-script/register')
+
+var charge = require('../..'),
+    connect = require('connect'),
+    http = require('http');
+
+// create a new charge app
+var app = charge(__dirname);
+
+// replace current logger as first in the stack
+app.stack.splice(0, 1, { route: '', handle: connect.logger('short') });
+
+http.createServer(app).listen(1111);


### PR DESCRIPTION
admittedly it isn't the strongest example, but I wanted to demonstrate that charge is simply an array of connect-compatible middleware and you can slice and dice it in anyway you wish. 

this example simply plucks out charge's default logger [morgan](https://github.com/expressjs/morgan) and replaces it with the old-school [connect.logger](www.senchalabs.org/connect/logger.html). 
